### PR TITLE
feat: add focusing mouse cursor on hint

### DIFF
--- a/src/HuntAndPeck/Models/UiAutomationSelectHint.cs
+++ b/src/HuntAndPeck/Models/UiAutomationSelectHint.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows;
+using System.Runtime.InteropServices;
 using UIAutomationClient;
 
 namespace HuntAndPeck.Models
@@ -11,6 +12,9 @@ namespace HuntAndPeck.Models
     {
         private readonly IUIAutomationSelectionItemPattern _selectPattern;
 
+        [DllImport("user32.dll")]
+        static extern bool SetCursorPos(int X, int Y);
+
         public UiAutomationSelectHint(IntPtr owningWindow, IUIAutomationSelectionItemPattern selectPattern, Rect boundingRectangle)
             : base(owningWindow, boundingRectangle)
         {
@@ -19,6 +23,14 @@ namespace HuntAndPeck.Models
 
         public override void Invoke()
         {
+            // Get the center of the hint bounding rectangle
+            double centerX = BoundingRectangle.Left + (BoundingRectangle.Width / 2);
+            double centerY = BoundingRectangle.Top + (BoundingRectangle.Height / 2);
+
+            // Move the mouse cursor to the center of the hint bounding rectangle
+            SetCursorPos((int)centerX, (int)centerY);
+
+            // Select the item
             _selectPattern.Select();
         }
     }


### PR DESCRIPTION
Issues:
- works properly only for apps in fullscreen mode (in window mode apps it still points the cursor to hints as if it was fullscreen mode - some scaling required)
- there are some hints this solution does not work for